### PR TITLE
[bugfix]: remove unused text_type

### DIFF
--- a/docassemble/ssa/ssa.py
+++ b/docassemble/ssa/ssa.py
@@ -1,4 +1,4 @@
-from docassemble.base.util import validation_error, Address, DAObject, DAList, text_type, Person, title_case
+from docassemble.base.util import validation_error, Address, DAObject, DAList, Person, title_case
 import re
 import requests
 


### PR DESCRIPTION
Some time between the initial code and now (version 1.4.9), the `text_type` function was removed from Docassemble. Seeing as it is unused here, it should be removed to work for future versions.